### PR TITLE
added metatag dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
     "drupal/address": "^1.2",
     "drupal/field_group": "^1.0@RC",
     "drupal/auto_entitylabel": "2.x-dev",
-    "drupal/eck": "^1.0@alpha"
+    "drupal/eck": "^1.0@alpha",
+    "drupal/metatag": "1.3"
   },
   "require-dev": {},
   "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "78ed7270e4a46a97d1c72bed53bd2f12",
+    "content-hash": "f94c95f14f9974c47587b76344a8f9e4",
     "packages": [
         {
             "name": "acquia/blt",
-            "version": "8.9.9",
+            "version": "8.9.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acquia/blt.git",
-                "reference": "b19c3d8e52ede749362454fac9b5f112eb5b56bd"
+                "reference": "8bf4845e778ca52c95e38cb1a68c63c1612b1e9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acquia/blt/zipball/b19c3d8e52ede749362454fac9b5f112eb5b56bd",
-                "reference": "b19c3d8e52ede749362454fac9b5f112eb5b56bd",
+                "url": "https://api.github.com/repos/acquia/blt/zipball/8bf4845e778ca52c95e38cb1a68c63c1612b1e9f",
+                "reference": "8bf4845e778ca52c95e38cb1a68c63c1612b1e9f",
                 "shasum": ""
             },
             "require": {
@@ -40,8 +40,8 @@
                 "php": ">=5.6",
                 "phpunit/phpunit": "^4.8",
                 "squizlabs/php_codesniffer": "^2.7",
-                "symfony/console": "^2.7|^3.2",
-                "symfony/yaml": "^2.7|^3.2",
+                "symfony/console": "^2.7|~3.2.8",
+                "symfony/yaml": "^2.7|~3.2.8",
                 "tivie/php-os-detector": "^1.0",
                 "wikimedia/composer-merge-plugin": "^1.4.1"
             },
@@ -87,7 +87,7 @@
                 "template",
                 "testing"
             ],
-            "time": "2017-10-16T20:21:48+00:00"
+            "time": "2017-10-26T00:06:55+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -608,16 +608,16 @@
         },
         {
             "name": "consolidation/config",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/config.git",
-                "reference": "a57ff3a302aac6f7e6fc0d81fe0778550a0fe9aa"
+                "reference": "b59a3b9ea750c21397f26a68fd2e04d9580af42e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/config/zipball/a57ff3a302aac6f7e6fc0d81fe0778550a0fe9aa",
-                "reference": "a57ff3a302aac6f7e6fc0d81fe0778550a0fe9aa",
+                "url": "https://api.github.com/repos/consolidation/config/zipball/b59a3b9ea750c21397f26a68fd2e04d9580af42e",
+                "reference": "b59a3b9ea750c21397f26a68fd2e04d9580af42e",
                 "shasum": ""
             },
             "require": {
@@ -653,7 +653,7 @@
                 }
             ],
             "description": "Provide configuration services for a commandline tool.",
-            "time": "2017-10-17T17:09:36+00:00"
+            "time": "2017-10-25T05:50:10+00:00"
         },
         {
             "name": "consolidation/log",
@@ -753,16 +753,16 @@
         },
         {
             "name": "consolidation/robo",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/Robo.git",
-                "reference": "ce11f3f842298ce6215c68c631af5b0420b18f53"
+                "reference": "aea695cebff81d54ed6daf14894738d5dac1c15c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/Robo/zipball/ce11f3f842298ce6215c68c631af5b0420b18f53",
-                "reference": "ce11f3f842298ce6215c68c631af5b0420b18f53",
+                "url": "https://api.github.com/repos/consolidation/Robo/zipball/aea695cebff81d54ed6daf14894738d5dac1c15c",
+                "reference": "aea695cebff81d54ed6daf14894738d5dac1c15c",
                 "shasum": ""
             },
             "require": {
@@ -786,7 +786,7 @@
                 "codeception/base": "^2.2.6",
                 "codeception/verify": "^0.3.2",
                 "henrikbjorn/lurker": "~1",
-                "natxet/cssmin": "~3",
+                "natxet/cssmin": "3.0.4",
                 "patchwork/jsqueeze": "~2",
                 "pear/archive_tar": "^1.4.2",
                 "phpunit/php-code-coverage": "~2|~4",
@@ -828,7 +828,7 @@
                 }
             ],
             "description": "Modern task runner",
-            "time": "2017-10-17T01:59:38+00:00"
+            "time": "2017-10-25T20:41:21+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -1742,14 +1742,6 @@
                     "homepage": "https://www.drupal.org/u/matio89"
                 },
                 {
-                    "name": "adriancid",
-                    "homepage": "https://www.drupal.org/user/1962106"
-                },
-                {
-                    "name": "bolbol",
-                    "homepage": "https://www.drupal.org/user/3400070"
-                },
-                {
                     "name": "eme",
                     "homepage": "https://www.drupal.org/user/542492"
                 },
@@ -1876,7 +1868,7 @@
                 "source": "http://cgit.drupalcode.org/auto_entitylabel",
                 "issues": "https://www.drupal.org/project/issues/auto_entitylabel"
             },
-            "time": "2017-08-02 16:08:09"
+            "time": "2017-08-02T16:08:09+00:00"
         },
         {
             "name": "drupal/chosen",
@@ -2037,7 +2029,7 @@
             "version": "8.2.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/klausi/coder.git",
+                "url": "https://git.drupal.org/project/coder.git",
                 "reference": "984c54a7b1e8f27ff1c32348df69712afd86b17f"
             },
             "dist": {
@@ -2963,7 +2955,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.1",
-                    "datestamp": "1506372845",
+                    "datestamp": "1470845408",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3042,6 +3034,70 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/linkit",
                 "issues": "http://drupal.org/project/linkit"
+            }
+        },
+        {
+            "name": "drupal/metatag",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/metatag",
+                "reference": "8.x-1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/metatag-8.x-1.3.zip",
+                "reference": "8.x-1.3",
+                "shasum": "5ff80fe91a1ea0446b11aef6c947259305080a38"
+            },
+            "require": {
+                "drupal/core": "*",
+                "drupal/token": "^1.0"
+            },
+            "require-dev": {
+                "drupal/devel": "^1.0",
+                "drupal/metatag_dc": "*",
+                "drupal/metatag_open_graph": "*",
+                "drupal/restui": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.3",
+                    "datestamp": "1506715150",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "See contributors",
+                    "homepage": "https://www.drupal.org/node/640498/committers",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                }
+            ],
+            "description": "Manage meta tags for all entities.",
+            "homepage": "https://www.drupal.org/project/metatag",
+            "keywords": [
+                "php",
+                "seo"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/metatag",
+                "issues": "http://drupal.org/project/issues/metatag"
             }
         },
         {
@@ -3437,7 +3493,7 @@
                 },
                 "drupal": {
                     "version": "8.x-5.0-beta18",
-                    "datestamp": "1506634743",
+                    "datestamp": "1505244243",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -5673,12 +5729,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-HSDO/stanford_mrc.git",
-                "reference": "648fbca7621c6211ad1a1141e5b5e4e540e5096b"
+                "reference": "f6eb37ebf1a94df98c4b98164a59e060b3911c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-HSDO/stanford_mrc/zipball/648fbca7621c6211ad1a1141e5b5e4e540e5096b",
-                "reference": "648fbca7621c6211ad1a1141e5b5e4e540e5096b",
+                "url": "https://api.github.com/repos/SU-HSDO/stanford_mrc/zipball/f6eb37ebf1a94df98c4b98164a59e060b3911c77",
+                "reference": "f6eb37ebf1a94df98c4b98164a59e060b3911c77",
                 "shasum": ""
             },
             "require": {
@@ -5693,7 +5749,7 @@
                 "source": "https://github.com/SU-HSDO/stanford_mrc/tree/8.x-1.x",
                 "issues": "https://github.com/SU-HSDO/stanford_mrc/issues"
             },
-            "time": "2017-10-24 17:03:51"
+            "time": "2017-10-30T22:28:26+00:00"
         },
         {
             "name": "su-sws/stanford_basic",
@@ -5701,12 +5757,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:SU-SWS/stanford_basic.git",
-                "reference": "021cd8aba709840bc66c8c5046b07f27b4780622"
+                "reference": "3aa581fb2b5fe5afe0fd0a6d66e7f4e022515e0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/stanford_basic/zipball/021cd8aba709840bc66c8c5046b07f27b4780622",
-                "reference": "021cd8aba709840bc66c8c5046b07f27b4780622",
+                "url": "https://api.github.com/repos/SU-SWS/stanford_basic/zipball/3aa581fb2b5fe5afe0fd0a6d66e7f4e022515e0d",
+                "reference": "3aa581fb2b5fe5afe0fd0a6d66e7f4e022515e0d",
                 "shasum": ""
             },
             "type": "stanford-theme",
@@ -5719,7 +5775,7 @@
                 "source": "https://github.com/SU-SWS/stanford_basic/tree/8.x-1.x",
                 "issues": "https://github.com/SU-SWS/stanford_basic/issues"
             },
-            "time": "2017-09-29 18:08:56"
+            "time": "2017-10-30T18:55:26+00:00"
         },
         {
             "name": "symfony-cmf/routing",
@@ -7123,16 +7179,16 @@
         },
         {
             "name": "webflo/drupal-finder",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webflo/drupal-finder.git",
-                "reference": "3216448cc347bc77127fa3bf6497ba9b3c296e9c"
+                "reference": "8a7886c575d6eaa67a425dceccc84e735c0b9637"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webflo/drupal-finder/zipball/3216448cc347bc77127fa3bf6497ba9b3c296e9c",
-                "reference": "3216448cc347bc77127fa3bf6497ba9b3c296e9c",
+                "url": "https://api.github.com/repos/webflo/drupal-finder/zipball/8a7886c575d6eaa67a425dceccc84e735c0b9637",
+                "reference": "8a7886c575d6eaa67a425dceccc84e735c0b9637",
                 "shasum": ""
             },
             "require-dev": {
@@ -7156,7 +7212,7 @@
                 }
             ],
             "description": "Helper class to locate a Drupal installation from a given path.",
-            "time": "2017-08-08T08:31:26+00:00"
+            "time": "2017-10-24T08:12:11+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding news content type needed metatag module

# Needed By (Date)
- End of sprint

# Urgency
- low

# Steps to Test

1. Use this branch for provisioning
2. Set stanford_mrc to use dev-MRCD8-80-news-content-type
3. Review that MRC News content type and dependencies are created(taxonomy, pathauto).

# Affected Projects or Products
- MRC
- https://github.com/SU-HSDO/stanford_mrc

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/MRCD8-80
- https://github.com/SU-HSDO/stanford_mrc/pull/4